### PR TITLE
Update base url to stop using deprecated endpoint

### DIFF
--- a/lib/hello_fax.rb
+++ b/lib/hello_fax.rb
@@ -6,7 +6,7 @@ module HelloFax
 
     include ::HTTMultiParty
 
-    base_uri "https://www.hellofax.com/apiapp.php/v1/"
+    base_uri "https://api.hellofax.com/v1/"
     headers 'User-Agent' => "hello_fax gem #{VERSION}"
 
     attr_accessor :guid


### PR DESCRIPTION
### Ticket
https://driverreach.atlassian.net/browse/DR-382

> We are writing to let you know of upcoming changes to the HelloFax API that will require you to implement changes. As of January 12, 2020 we will no longer be accepting API calls to the www.hellofax.com/apiapp.php endpoint. Instead, API calls should use the api.hellofax.com subdomain. 
> 
> Please search your code and configuration for references to www.hellofax.com/apiapp.php and replace them with api.hellofax.com

### Migration
N/A

### Release notes
- Update API endpoint url